### PR TITLE
Handle 'real' lists and sets in the IOU function

### DIFF
--- a/app.py
+++ b/app.py
@@ -257,7 +257,7 @@ def content_gui():
             # Error message if neither is provided
             flash("Please provide at least a title or content query.")
         else:
-            results, csv_data = None
+            results, csv_data = (None, None)
             results, csv_data = content(request)
             
     return render_template('index.html', results=results, csv_data=csv_data, countries=COUNTRIES, languages=LANGUAGES, indicator_metadata=INDICATOR_METADATA)

--- a/modules/crawler.py
+++ b/modules/crawler.py
@@ -30,6 +30,7 @@ from modules.id_patterns import EMBEDDED_IDS, SOCIAL_MEDIA_IDS, TRACKING_IDS
 
 URLSCAN_API_KEY = os.getenv('URLSCAN_API_KEY')
 SCRAPER_API_KEY = os.getenv('SCRAPER_API_KEY')
+MYIPMS_API_PATH = os.getenv('MYIPMS_API_PATH', '')
 
 visited = set()
 

--- a/tests/test__matcher.py
+++ b/tests/test__matcher.py
@@ -18,13 +18,22 @@ from modules.matcher import (
 def feature_group_as_list_1():
     return pd.DataFrame(
                 [
+                    {DOMAIN: "a", INDICATOR_TYPE: INDICATOR_TYPE, INDICATOR: [1, 2, 3]},
+                    {DOMAIN: "b", INDICATOR_TYPE: INDICATOR_TYPE, INDICATOR: [3, 4, 5]},
+                    {DOMAIN: "c", INDICATOR_TYPE: INDICATOR_TYPE, INDICATOR: [4, 5, 6]},
+                ]
+            )
+
+def feature_group_as_list_str_1():
+    return pd.DataFrame(
+                [
                     {DOMAIN: "a", INDICATOR_TYPE: INDICATOR_TYPE, INDICATOR: "[1, 2, 3]"},
                     {DOMAIN: "b", INDICATOR_TYPE: INDICATOR_TYPE, INDICATOR: "[3, 4, 5]"},
                     {DOMAIN: "c", INDICATOR_TYPE: INDICATOR_TYPE, INDICATOR: "[4, 5, 6]"},
                 ]
             )
 
-def feature_group_as_list_2():
+def feature_group_as_list_str_2():
     return pd.DataFrame(
                 columns=[DOMAIN, INDICATOR, INDICATOR_TYPE],
                 data=[
@@ -96,8 +105,9 @@ def test__find_direct_matches(feature_df, compare_df, expected_results):
 @pytest.mark.parametrize(
     "feature_df,compare_df,expected_results",
     [
-        (   feature_group_as_list_1(),
-            feature_group_as_list_1(),
+        pytest.param(
+            feature_group_as_list_str_1(),
+            feature_group_as_list_str_1(),
             pd.DataFrame(
                 [
                     {
@@ -120,8 +130,34 @@ def test__find_direct_matches(feature_df, compare_df, expected_results):
                     },
                 ]
             ),
-        ),
-        (
+        id="listlike strings, same values"),
+        pytest.param(
+            feature_group_as_list_1(),
+            feature_group_as_list_str_1(),
+            pd.DataFrame(
+                [
+                    {
+                        "domain_name_x": "a",
+                        "domain_name_y": "b",
+                        "match_type": "feature",
+                        "match_value": 0.2,
+                    },
+                    {
+                        "domain_name_x": "a",
+                        "domain_name_y": "c",
+                        "match_type": "feature",
+                        "match_value": 0.0,
+                    },
+                    {
+                        "domain_name_x": "b",
+                        "domain_name_y": "c",
+                        "match_type": "feature",
+                        "match_value": 0.5,
+                    },
+                ]
+            ),
+        id="one list, one listlike string, same values"),
+        pytest.param(
             feature_group_as_string_1(),
             feature_group_as_string_1(),
             pd.DataFrame(
@@ -146,14 +182,14 @@ def test__find_direct_matches(feature_df, compare_df, expected_results):
                     },
                 ]
             ),
-        ),
-        (
-            feature_group_as_list_1(),
-            feature_group_as_list_2(),
+        id="two set-like strings, same values"),
+        pytest.param(
+            feature_group_as_list_str_1(),
+            feature_group_as_list_str_2(),
             pd.DataFrame(
                 columns=["domain_name_x", "domain_name_y", "match_type", "match_value"]
             ),
-        ),
+        id="two listlike strings, different values"),
     ],
 )
 def test__find_iou_matches(feature_df, compare_df, expected_results):
@@ -175,8 +211,8 @@ def test__parse_certificate_matches():
     "feature_df,compare_df,expected_results",
     [
         (
-            feature_group_as_list_1(),
-            feature_group_as_list_1(),
+            feature_group_as_list_str_1(),
+            feature_group_as_list_str_1(),
             pd.DataFrame(
                 [
                     {
@@ -219,8 +255,8 @@ def test__parse_certificate_matches():
             )
         ),
         (
-            feature_group_as_list_1(),
-            feature_group_as_list_2(),
+            feature_group_as_list_str_1(),
+            feature_group_as_list_str_2(),
             pd.DataFrame(
                 columns=["domain_name_x", "domain_name_y", "match_type", "match_value"],
                 data=[]


### PR DESCRIPTION
When we crawl a website, we get new indicator values that retain their original types (lists or sets). This is different from teh indicator values we read from value, which have to be converted from strings.

This adds in the way to check and handle original lists and sets correctly, as well as a new test case to check this.