### PR TITLE
easier way to set variable thresholds

### DIFF
--- a/modules/matcher.py
+++ b/modules/matcher.py
@@ -9,7 +9,7 @@ import pandas as pd
 from pandas.api.types import is_list_like
 from pathlib import Path
 import traceback
-from typing import Dict, Any
+from typing import Any
 
 from modules.indicators import EMBEDDED_IDS, FINANCIAL_IDS, SOCIAL_MEDIA_IDS, TRACKING_IDS
 ## Preprocessing
@@ -86,7 +86,7 @@ def feature_df_preprocess(feature_df: pd.DataFrame, feature: str) -> pd.DataFram
 
 
 # urlscan certificate
-def prefix_keys(data_dict: Dict[str, Any], prefix: str) -> Dict[str, Any]:
+def prefix_keys(data_dict: dict[str, Any], prefix: str) -> dict[str, Any]:
     new_dict = {}
     for key in data_dict.keys():
         new_dict[f"{prefix}-{key}"] = data_dict[key]
@@ -239,68 +239,68 @@ def parse_certificate_matches(
 
 
 ## Main program
-FEATURE_MATCHING: Dict[str, str] = {
-"1-cert-domain" : "direct",
-"1-crypto-wallet" : "direct",
-"1-domain" : "direct",
-"1-domain_suffix" : "direct",
-"1-fb_pixel_id" : "direct",
-"1-adobe_analytics_id" : "direct",
-"3-sitemap_entries" : "direct",
-"3-ipms_domain_iprangeowner_cidr" : "direct",
-"3-ipms_domain_iprangeowner_ownerName" : "direct",
-"3-ipms_domain_iprangeowner_address" : "direct",
-"3-ipms_domain_nameserver" : "direct",
-"3-ipms_domain_otheripused" : "direct",
-"3-ipms_siteonthisip_now" : "direct",
-"3-ipms_siteonthisip_before" : "direct",
-"3-ipms_siteonthisip_broken" : "direct",
-"3-ipms_useragents" : "direct",
-"1-ip_shodan_hostnames" : "direct",
-"3-ip_shodan_ports" : "iou",
-"2-ip_shodan_vuln" : "iou",
-"3-ip_shodan_cpe" : "iou",
-"1-ga_id" : "direct",
-"1-ga_tag_id" : "direct",
-"1-ip" : "direct",
-"1-verification_id" : "direct",
-"1-yandex_tag_id" : "direct",
-"2-subnet" : "direct",
-"3-cdn-domain" : "direct",
-"3-cms" : "direct",
-"3-css_classes" : "iou",
-"3-header-nonstd-value" : "direct",
-"3-header-server" : "direct",
-"3-id_tags" : "iou",
-"3-iframe_id_tags" : "iou",
-"3-link_href" : "iou",
-"3-meta_generic" : "iou",
-"3-meta_social" : "direct",
-"3-script_src" : "iou",
-"3-uuid" : "direct",
-"3-whois_creation_date" : "direct",
-"3-whois_server" : "direct",
-"3-whois-registrar" : "direct",
-"3-wp-blocks" : "iou",
-"3-wp-categories" : "iou",
-"3-wp-pages" : "iou",
-"3-wp-posts" : "iou",
-"3-wp-tags" : "iou",
-"3-wp-users" : "iou",
-"2-urlscan_globalvariable": "iou",
-"2-urlscan_cookies": "iou",
-"2-urlscan_consolemessages": "iou",
-"2-urlscan_asn": "direct",
-"2-urlscan_domainsonpage": "iou",
-"2-urlscan_urlssonpage" : "iou",
-"2-urlscanhrefs" : "iou",
-"2-techstack" : "iou"
+FEATURE_MATCHING: dict[str, dict[str, dict[str, Any]]] = {
+"1-cert-domain" : {"match": {"method": "direct"}},
+"1-crypto-wallet" : {"match": {"method": "direct"}},
+"1-domain" : {"match": {"method": "direct"}},
+"1-domain_suffix" : {"match": {"method": "direct"}},
+"1-fb_pixel_id" : {"match": {"method": "direct"}},
+"1-adobe_analytics_id" : {"match": {"method": "direct"}},
+"3-sitemap_entries" : {"match": {"method": "direct"}},
+"3-ipms_domain_iprangeowner_cidr" : {"match": {"method": "direct"}},
+"3-ipms_domain_iprangeowner_ownerName" : {"match": {"method": "direct"}},
+"3-ipms_domain_iprangeowner_address" : {"match": {"method": "direct"}},
+"3-ipms_domain_nameserver" : {"match": {"method": "direct"}},
+"3-ipms_domain_otheripused" : {"match": {"method": "direct"}},
+"3-ipms_siteonthisip_now" : {"match": {"method": "direct"}},
+"3-ipms_siteonthisip_before" : {"match": {"method": "direct"}},
+"3-ipms_siteonthisip_broken" : {"match": {"method": "direct"}},
+"3-ipms_useragents" : {"match": {"method": "direct"}},
+"1-ip_shodan_hostnames" : {"match": {"method": "direct"}},
+"3-ip_shodan_ports" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"2-ip_shodan_vuln" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-ip_shodan_cpe" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"1-ga_id" : {"match": {"method": "direct"}},
+"1-ga_tag_id" : {"match": {"method": "direct"}},
+"1-ip" : {"match": {"method": "direct"}},
+"1-verification_id" : {"match": {"method": "direct"}},
+"1-yandex_tag_id" : {"match": {"method": "direct"}},
+"2-subnet" : {"match": {"method": "direct"}},
+"3-cdn-domain" : {"match": {"method": "direct"}},
+"3-cms" : {"match": {"method": "direct"}},
+"3-css_classes" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-header-nonstd-value" : {"match": {"method": "direct"}},
+"3-header-server" : {"match": {"method": "direct"}},
+"3-id_tags" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-iframe_id_tags" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-link_href" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-meta_generic" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-meta_social" : {"match": {"method": "direct"}},
+"3-script_src" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-uuid" : {"match": {"method": "direct"}},
+"3-whois_creation_date" : {"match": {"method": "direct"}},
+"3-whois_server" : {"match": {"method": "direct"}},
+"3-whois-registrar" : {"match": {"method": "direct"}},
+"3-wp-blocks" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-wp-categories" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-wp-pages" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-wp-posts" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-wp-tags" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"3-wp-users" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"2-urlscan_globalvariable": {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"2-urlscan_cookies": {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"2-urlscan_consolemessages": {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"2-urlscan_asn": {"match": {"method": "direct"}},
+"2-urlscan_domainsonpage": {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"2-urlscan_urlssonpage" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"2-urlscanhrefs" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
+"2-techstack" : {"match": {"method": "iou", "args": {"threshold": 0.9}}}
 }
 
-FEATURE_MATCHING.update({financial_id: "direct" for financial_id in FINANCIAL_IDS})
-FEATURE_MATCHING.update({embedded_id: "direct" for embedded_id in EMBEDDED_IDS})
-FEATURE_MATCHING.update({social_id: "direct" for social_id in SOCIAL_MEDIA_IDS})
-FEATURE_MATCHING.update({tracking_id: "direct" for tracking_id in TRACKING_IDS})
+FEATURE_MATCHING.update({financial_id: {"match": {"method": "direct"}} for financial_id in FINANCIAL_IDS})
+FEATURE_MATCHING.update({embedded_id: {"match": {"method": "direct"}} for embedded_id in EMBEDDED_IDS})
+FEATURE_MATCHING.update({social_id: {"match": {"method": "direct"}} for social_id in SOCIAL_MEDIA_IDS})
+FEATURE_MATCHING.update({tracking_id: {"match": {"method": "direct"}} for tracking_id in TRACKING_IDS})
 
 WHOIS_FEATURES = [
     "whois-registrar",
@@ -343,16 +343,21 @@ def find_matches(data, comparison=None, result_dir=None) -> pd.DataFrame:
         comparison = data
 
     for feature in unique_features:
-        method = FEATURE_MATCHING.get(feature)
-        if not method:
+        match_func = FEATURE_MATCHING.get(feature, {}).get("match")
+        if not match_func:
             logging.error(f"MISSING FEATURE MATCHING METHOD FOR: {feature}")
             continue
-        logging.info(f"Matching {feature} with method: {method}")
+        logging.info(f"Matching {feature} with method: {match_func}")
         feature_df = data[data[INDICATOR_TYPE] == feature]
         comparison_df = comparison[comparison[INDICATOR_TYPE] == feature]
         try:
+            method = match_func["method"]
+            args = match_func.get("args", {})
             feature_matches = methods[method](
-                feature_df=feature_df, feature=feature, comparison_df=comparison_df
+                feature_df=feature_df,
+                feature=feature,
+                comparison_df=comparison_df,
+                **args
             )
             matches_per_feature.append(feature_matches)
             if result_dir:

--- a/modules/matcher.py
+++ b/modules/matcher.py
@@ -110,7 +110,7 @@ def cert_preprocess(df: pd.DataFrame, cert_feature: str) -> pd.DataFrame:
 ## Matching
 
 
-def find_direct_matches(
+def direct_match(
     feature_df: pd.DataFrame,
     feature: str,
     comparison_df: pd.DataFrame,
@@ -128,7 +128,7 @@ def find_direct_matches(
     return matches.reset_index(drop=True)
 
 
-def find_iou_matches(
+def iou_match(
     feature_df: pd.DataFrame,
     feature: str,
     comparison_df: pd.DataFrame,
@@ -164,7 +164,7 @@ def find_iou_matches(
 
     return result
 
-def find_any_in_list_matches(
+def any_in_list_match(
         feature_df: pd.DataFrame,
         comparison_df: pd.DataFrame,
         feature: str,
@@ -201,7 +201,7 @@ def parse_whois_matches(
     for sub_feature in WHOIS_FEATURES:
         whois_feature_df = feature_df_preprocess(whois_df, sub_feature)
         whois_feature_comparison_df = feature_df_preprocess(whois_comparison_df, sub_feature)
-        matches = find_direct_matches(
+        matches = direct_match(
             whois_feature_df,
             feature=sub_feature,
             comparison_df=whois_feature_comparison_df,
@@ -227,7 +227,7 @@ def parse_certificate_matches(
         cert_feature_comparison_df = feature_df_preprocess(
             cert_comparison_df, sub_feature
         )
-        matches = find_direct_matches(
+        matches = direct_match(
             cert_feature_df,
             feature=sub_feature,
             comparison_df=cert_feature_comparison_df,
@@ -239,68 +239,68 @@ def parse_certificate_matches(
 
 
 ## Main program
-FEATURE_MATCHING: dict[str, Callable[[pd.DataFrame, str, pd.DataFrame, Any], pd.DataFrame]] = {
-"1-cert-domain" : find_direct_matches,
-"1-crypto-wallet" : find_direct_matches,
-"1-domain" : find_direct_matches,
-"1-domain_suffix" : find_direct_matches,
-"1-fb_pixel_id" : find_direct_matches,
-"1-adobe_analytics_id" : find_direct_matches,
-"3-sitemap_entries" : find_direct_matches,
-"3-ipms_domain_iprangeowner_cidr" : find_direct_matches,
-"3-ipms_domain_iprangeowner_ownerName" : find_direct_matches,
-"3-ipms_domain_iprangeowner_address" : find_direct_matches,
-"3-ipms_domain_nameserver" : find_direct_matches,
-"3-ipms_domain_otheripused" : find_direct_matches,
-"3-ipms_siteonthisip_now" : find_direct_matches,
-"3-ipms_siteonthisip_before" : find_direct_matches,
-"3-ipms_siteonthisip_broken" : find_direct_matches,
-"3-ipms_useragents" : find_direct_matches,
-"1-ip_shodan_hostnames" : find_direct_matches,
-"3-ip_shodan_ports" : find_iou_matches,
-"2-ip_shodan_vuln" : partial(find_iou_matches, threshold=0.5),
-"3-ip_shodan_cpe" : find_iou_matches,
-"1-ga_id" : find_direct_matches,
-"1-ga_tag_id" : find_direct_matches,
-"1-ip" : find_direct_matches,
-"1-verification_id" : find_direct_matches,
-"1-yandex_tag_id" : find_direct_matches,
-"2-subnet" : find_direct_matches,
-"3-cdn-domain" : find_direct_matches,
-"3-cms" : find_direct_matches,
-"3-css_classes" : find_iou_matches,
-"3-header-nonstd-value" : find_direct_matches,
-"3-header-server" : find_direct_matches,
-"3-id_tags" : find_iou_matches,
-"3-iframe_id_tags" : find_iou_matches,
-"3-link_href" : find_iou_matches,
-"3-meta_generic" : find_iou_matches,
-"3-meta_social" : find_direct_matches,
-"3-script_src" : find_iou_matches,
-"3-uuid" : find_direct_matches,
-"3-whois_creation_date" : find_direct_matches,
-"3-whois_server" : find_direct_matches,
-"3-whois-registrar" : find_direct_matches,
-"3-wp-blocks" : find_iou_matches,
-"3-wp-categories" : find_iou_matches,
-"3-wp-pages" : find_iou_matches,
-"3-wp-posts" : find_iou_matches,
-"3-wp-tags" : find_iou_matches,
-"3-wp-users" : find_iou_matches,
-"2-urlscan_globalvariable": find_iou_matches,
-"2-urlscan_cookies": find_iou_matches,
-"2-urlscan_consolemessages": find_iou_matches,
-"2-urlscan_asn": find_direct_matches,
-"2-urlscan_domainsonpage": find_iou_matches,
-"2-urlscan_urlssonpage" : find_iou_matches,
-"2-urlscanhrefs" : find_iou_matches,
-"2-techstack" : find_iou_matches
+FEATURE_MATCHING: dict[str, Callable[[pd.DataFrame, str, pd.DataFrame], pd.DataFrame]] = {
+"1-cert-domain" : direct_match,
+"1-crypto-wallet" : direct_match,
+"1-domain" : direct_match,
+"1-domain_suffix" : direct_match,
+"1-fb_pixel_id" : direct_match,
+"1-adobe_analytics_id" : direct_match,
+"3-sitemap_entries" : direct_match,
+"3-ipms_domain_iprangeowner_cidr" : direct_match,
+"3-ipms_domain_iprangeowner_ownerName" : direct_match,
+"3-ipms_domain_iprangeowner_address" : direct_match,
+"3-ipms_domain_nameserver" : direct_match,
+"3-ipms_domain_otheripused" : direct_match,
+"3-ipms_siteonthisip_now" : direct_match,
+"3-ipms_siteonthisip_before" : direct_match,
+"3-ipms_siteonthisip_broken" : direct_match,
+"3-ipms_useragents" : direct_match,
+"1-ip_shodan_hostnames" : direct_match,
+"3-ip_shodan_ports" : iou_match,
+"2-ip_shodan_vuln" : partial(iou_match, threshold=0.5),
+"3-ip_shodan_cpe" : iou_match,
+"1-ga_id" : direct_match,
+"1-ga_tag_id" : direct_match,
+"1-ip" : direct_match,
+"1-verification_id" : direct_match,
+"1-yandex_tag_id" : direct_match,
+"2-subnet" : direct_match,
+"3-cdn-domain" : direct_match,
+"3-cms" : direct_match,
+"3-css_classes" : iou_match,
+"3-header-nonstd-value" : direct_match,
+"3-header-server" : direct_match,
+"3-id_tags" : iou_match,
+"3-iframe_id_tags" : iou_match,
+"3-link_href" : iou_match,
+"3-meta_generic" : iou_match,
+"3-meta_social" : direct_match,
+"3-script_src" : iou_match,
+"3-uuid" : direct_match,
+"3-whois_creation_date" : direct_match,
+"3-whois_server" : direct_match,
+"3-whois-registrar" : direct_match,
+"3-wp-blocks" : iou_match,
+"3-wp-categories" : iou_match,
+"3-wp-pages" : iou_match,
+"3-wp-posts" : iou_match,
+"3-wp-tags" : iou_match,
+"3-wp-users" : iou_match,
+"2-urlscan_globalvariable": iou_match,
+"2-urlscan_cookies": iou_match,
+"2-urlscan_consolemessages": iou_match,
+"2-urlscan_asn": direct_match,
+"2-urlscan_domainsonpage": iou_match,
+"2-urlscan_urlssonpage" : iou_match,
+"2-urlscanhrefs" : iou_match,
+"2-techstack" : iou_match
 }
 
-FEATURE_MATCHING.update({financial_id: find_direct_matches for financial_id in FINANCIAL_IDS})
-FEATURE_MATCHING.update({embedded_id: find_direct_matches for embedded_id in EMBEDDED_IDS})
-FEATURE_MATCHING.update({social_id: find_direct_matches for social_id in SOCIAL_MEDIA_IDS})
-FEATURE_MATCHING.update({tracking_id: find_direct_matches for tracking_id in TRACKING_IDS})
+FEATURE_MATCHING.update({financial_id: direct_match for financial_id in FINANCIAL_IDS})
+FEATURE_MATCHING.update({embedded_id: direct_match for embedded_id in EMBEDDED_IDS})
+FEATURE_MATCHING.update({social_id: direct_match for social_id in SOCIAL_MEDIA_IDS})
+FEATURE_MATCHING.update({tracking_id: direct_match for tracking_id in TRACKING_IDS})
 
 WHOIS_FEATURES = [
     "whois-registrar",
@@ -336,7 +336,7 @@ def find_matches(data, comparison=None, result_dir=None) -> pd.DataFrame:
         comparison_df = comparison[comparison[INDICATOR_TYPE] == feature]
         try:
             feature_matches = match_func(
-                feature_df=feature_df,
+                feature_df=feature_df,  # type: ignore
                 feature=feature,
                 comparison_df=comparison_df
             )

--- a/modules/matcher.py
+++ b/modules/matcher.py
@@ -239,68 +239,68 @@ def parse_certificate_matches(
 
 
 ## Main program
-FEATURE_MATCHING: dict[str, dict[str, dict[str, Any]]] = {
-"1-cert-domain" : {"match": {"method": "direct"}},
-"1-crypto-wallet" : {"match": {"method": "direct"}},
-"1-domain" : {"match": {"method": "direct"}},
-"1-domain_suffix" : {"match": {"method": "direct"}},
-"1-fb_pixel_id" : {"match": {"method": "direct"}},
-"1-adobe_analytics_id" : {"match": {"method": "direct"}},
-"3-sitemap_entries" : {"match": {"method": "direct"}},
-"3-ipms_domain_iprangeowner_cidr" : {"match": {"method": "direct"}},
-"3-ipms_domain_iprangeowner_ownerName" : {"match": {"method": "direct"}},
-"3-ipms_domain_iprangeowner_address" : {"match": {"method": "direct"}},
-"3-ipms_domain_nameserver" : {"match": {"method": "direct"}},
-"3-ipms_domain_otheripused" : {"match": {"method": "direct"}},
-"3-ipms_siteonthisip_now" : {"match": {"method": "direct"}},
-"3-ipms_siteonthisip_before" : {"match": {"method": "direct"}},
-"3-ipms_siteonthisip_broken" : {"match": {"method": "direct"}},
-"3-ipms_useragents" : {"match": {"method": "direct"}},
-"1-ip_shodan_hostnames" : {"match": {"method": "direct"}},
-"3-ip_shodan_ports" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"2-ip_shodan_vuln" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-ip_shodan_cpe" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"1-ga_id" : {"match": {"method": "direct"}},
-"1-ga_tag_id" : {"match": {"method": "direct"}},
-"1-ip" : {"match": {"method": "direct"}},
-"1-verification_id" : {"match": {"method": "direct"}},
-"1-yandex_tag_id" : {"match": {"method": "direct"}},
-"2-subnet" : {"match": {"method": "direct"}},
-"3-cdn-domain" : {"match": {"method": "direct"}},
-"3-cms" : {"match": {"method": "direct"}},
-"3-css_classes" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-header-nonstd-value" : {"match": {"method": "direct"}},
-"3-header-server" : {"match": {"method": "direct"}},
-"3-id_tags" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-iframe_id_tags" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-link_href" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-meta_generic" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-meta_social" : {"match": {"method": "direct"}},
-"3-script_src" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-uuid" : {"match": {"method": "direct"}},
-"3-whois_creation_date" : {"match": {"method": "direct"}},
-"3-whois_server" : {"match": {"method": "direct"}},
-"3-whois-registrar" : {"match": {"method": "direct"}},
-"3-wp-blocks" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-wp-categories" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-wp-pages" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-wp-posts" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-wp-tags" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"3-wp-users" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"2-urlscan_globalvariable": {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"2-urlscan_cookies": {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"2-urlscan_consolemessages": {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"2-urlscan_asn": {"match": {"method": "direct"}},
-"2-urlscan_domainsonpage": {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"2-urlscan_urlssonpage" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"2-urlscanhrefs" : {"match": {"method": "iou", "args": {"threshold": 0.9}}},
-"2-techstack" : {"match": {"method": "iou", "args": {"threshold": 0.9}}}
+FEATURE_MATCHING: dict[str, Any] = {
+"1-cert-domain" : find_direct_matches,
+"1-crypto-wallet" : find_direct_matches,
+"1-domain" : find_direct_matches,
+"1-domain_suffix" : find_direct_matches,
+"1-fb_pixel_id" : find_direct_matches,
+"1-adobe_analytics_id" : find_direct_matches,
+"3-sitemap_entries" : find_direct_matches,
+"3-ipms_domain_iprangeowner_cidr" : find_direct_matches,
+"3-ipms_domain_iprangeowner_ownerName" : find_direct_matches,
+"3-ipms_domain_iprangeowner_address" : find_direct_matches,
+"3-ipms_domain_nameserver" : find_direct_matches,
+"3-ipms_domain_otheripused" : find_direct_matches,
+"3-ipms_siteonthisip_now" : find_direct_matches,
+"3-ipms_siteonthisip_before" : find_direct_matches,
+"3-ipms_siteonthisip_broken" : find_direct_matches,
+"3-ipms_useragents" : find_direct_matches,
+"1-ip_shodan_hostnames" : find_direct_matches,
+"3-ip_shodan_ports" : find_iou_matches,
+"2-ip_shodan_vuln" : partial(find_iou_matches, threshold=0.5),
+"3-ip_shodan_cpe" : find_iou_matches,
+"1-ga_id" : find_direct_matches,
+"1-ga_tag_id" : find_direct_matches,
+"1-ip" : find_direct_matches,
+"1-verification_id" : find_direct_matches,
+"1-yandex_tag_id" : find_direct_matches,
+"2-subnet" : find_direct_matches,
+"3-cdn-domain" : find_direct_matches,
+"3-cms" : find_direct_matches,
+"3-css_classes" : find_iou_matches,
+"3-header-nonstd-value" : find_direct_matches,
+"3-header-server" : find_direct_matches,
+"3-id_tags" : find_iou_matches,
+"3-iframe_id_tags" : find_iou_matches,
+"3-link_href" : find_iou_matches,
+"3-meta_generic" : find_iou_matches,
+"3-meta_social" : find_direct_matches,
+"3-script_src" : find_iou_matches,
+"3-uuid" : find_direct_matches,
+"3-whois_creation_date" : find_direct_matches,
+"3-whois_server" : find_direct_matches,
+"3-whois-registrar" : find_direct_matches,
+"3-wp-blocks" : find_iou_matches,
+"3-wp-categories" : find_iou_matches,
+"3-wp-pages" : find_iou_matches,
+"3-wp-posts" : find_iou_matches,
+"3-wp-tags" : find_iou_matches,
+"3-wp-users" : find_iou_matches,
+"2-urlscan_globalvariable": find_iou_matches,
+"2-urlscan_cookies": find_iou_matches,
+"2-urlscan_consolemessages": find_iou_matches,
+"2-urlscan_asn": find_direct_matches,
+"2-urlscan_domainsonpage": find_iou_matches,
+"2-urlscan_urlssonpage" : find_iou_matches,
+"2-urlscanhrefs" : find_iou_matches,
+"2-techstack" : find_iou_matches
 }
 
-FEATURE_MATCHING.update({financial_id: {"match": {"method": "direct"}} for financial_id in FINANCIAL_IDS})
-FEATURE_MATCHING.update({embedded_id: {"match": {"method": "direct"}} for embedded_id in EMBEDDED_IDS})
-FEATURE_MATCHING.update({social_id: {"match": {"method": "direct"}} for social_id in SOCIAL_MEDIA_IDS})
-FEATURE_MATCHING.update({tracking_id: {"match": {"method": "direct"}} for tracking_id in TRACKING_IDS})
+FEATURE_MATCHING.update({financial_id: find_direct_matches for financial_id in FINANCIAL_IDS})
+FEATURE_MATCHING.update({embedded_id: find_direct_matches for embedded_id in EMBEDDED_IDS})
+FEATURE_MATCHING.update({social_id: find_direct_matches for social_id in SOCIAL_MEDIA_IDS})
+FEATURE_MATCHING.update({tracking_id: find_direct_matches for tracking_id in TRACKING_IDS})
 
 WHOIS_FEATURES = [
     "whois-registrar",
@@ -343,21 +343,21 @@ def find_matches(data, comparison=None, result_dir=None) -> pd.DataFrame:
         comparison = data
 
     for feature in unique_features:
-        match_func = FEATURE_MATCHING.get(feature, {}).get("match")
+        match_func = FEATURE_MATCHING.get(feature, None)
         if not match_func:
             logging.error(f"MISSING FEATURE MATCHING METHOD FOR: {feature}")
             continue
-        logging.info(f"Matching {feature} with method: {match_func}")
+        try:
+            logging.info(f"Matching {feature} with method: {match_func.__name__}")
+        except AttributeError:
+            logging.info(f"Matching {feature} with method: {match_func.func.__name__}, {match_func.keywords}")
         feature_df = data[data[INDICATOR_TYPE] == feature]
         comparison_df = comparison[comparison[INDICATOR_TYPE] == feature]
         try:
-            method = match_func["method"]
-            args = match_func.get("args", {})
-            feature_matches = methods[method](
+            feature_matches = match_func(
                 feature_df=feature_df,
                 feature=feature,
-                comparison_df=comparison_df,
-                **args
+                comparison_df=comparison_df
             )
             matches_per_feature.append(feature_matches)
             if result_dir:
@@ -366,7 +366,6 @@ def find_matches(data, comparison=None, result_dir=None) -> pd.DataFrame:
                 )
         except Exception as e:
             logging.error(f"Error matching feature {feature}: {traceback.print_stack()}")
-            #raise(e)
             continue
     all_matches = pd.concat(matches_per_feature)
     return all_matches

--- a/modules/matcher.py
+++ b/modules/matcher.py
@@ -9,7 +9,7 @@ import pandas as pd
 from pandas.api.types import is_list_like
 from pathlib import Path
 import traceback
-from typing import Any
+from typing import Any, Callable
 
 from modules.indicators import EMBEDDED_IDS, FINANCIAL_IDS, SOCIAL_MEDIA_IDS, TRACKING_IDS
 ## Preprocessing
@@ -239,7 +239,7 @@ def parse_certificate_matches(
 
 
 ## Main program
-FEATURE_MATCHING: dict[str, Any] = {
+FEATURE_MATCHING: dict[str, Callable[[pd.DataFrame, str, pd.DataFrame, Any], pd.DataFrame]] = {
 "1-cert-domain" : find_direct_matches,
 "1-crypto-wallet" : find_direct_matches,
 "1-domain" : find_direct_matches,
@@ -314,25 +314,6 @@ WHOIS_FEATURES = [
 URLSCAN_CERT_FEATURES = ["certificate-subjectName"]
 
 DICT_FEATURES = {"whois": WHOIS_FEATURES, "certificate": URLSCAN_CERT_FEATURES}
-
-# to add a new method, write a function with the expected arguments:
-# - feature_df,
-# - feature,
-# - comparison_df
-# then add the method to this dictionary. to use the method on a feature, set the value
-# of a feature in the FEATURE_MATCHING dictionary above to the label/key you use in this dictionary.
-methods = {
-    "direct": find_direct_matches,
-    "whois": parse_whois_matches,
-    "certificate": parse_certificate_matches,
-    "iou": find_iou_matches,
-    "any_in_list": find_any_in_list_matches,
-    # "dict_direct_match"
-    # "intersection"
-    # "iou"
-    # "abs_difference_vs_threshold"
-}
-# todo add 'any in list" match
 
 
 def find_matches(data, comparison=None, result_dir=None) -> pd.DataFrame:

--- a/tests/test__matcher.py
+++ b/tests/test__matcher.py
@@ -3,9 +3,9 @@ import pandas as pd
 from unittest import mock
 
 from modules.matcher import (
-    find_any_in_list_matches,
-    find_direct_matches,
-    find_iou_matches,
+    any_in_list_match,
+    direct_match,
+    iou_match,
     find_matches,
     main,
     DOMAIN,
@@ -97,8 +97,8 @@ def feature_group_as_string_1():
         ),
     ],
 )
-def test__find_direct_matches(feature_df, compare_df, expected_results):
-    matches = find_direct_matches(feature_df, "feature", compare_df)
+def test__direct_match(feature_df, compare_df, expected_results):
+    matches = direct_match(feature_df, "feature", compare_df)
     pd.testing.assert_frame_equal(matches, expected_results, check_index_type=False)
 
 
@@ -192,8 +192,8 @@ def test__find_direct_matches(feature_df, compare_df, expected_results):
         id="two listlike strings, different values"),
     ],
 )
-def test__find_iou_matches(feature_df, compare_df, expected_results):
-    results = find_iou_matches(
+def test__iou_match(feature_df, compare_df, expected_results):
+    results = iou_match(
         feature_df=feature_df, comparison_df=compare_df, feature="feature", threshold=0
     )
     results = results.drop("matched_on", axis=1)  # can't compare equality of sets
@@ -264,8 +264,8 @@ def test__parse_certificate_matches():
         ),
     ]
 )
-def test__find_any_in_list_matches(feature_df, compare_df, expected_results):
-    results = find_any_in_list_matches(feature_df, compare_df, feature='feature')
+def test__any_in_list_match(feature_df, compare_df, expected_results):
+    results = any_in_list_match(feature_df, compare_df, feature='feature')
     results = results.drop("matched_on", axis=1)
     pd.testing.assert_frame_equal(results, expected_results, check_index_type=False)
 


### PR DESCRIPTION
Removed a lot of unnecessary code, so now we refer to the matching function directly. Now we can set thresholds (and other matching arguments) just like this example:

<img width="568" alt="Screenshot 2024-03-09 at 22 43 23" src="https://github.com/ASD-at-GMF/disinfo-laundromat/assets/4691842/fa27f31e-4c7d-46b7-8afe-461b1891768d">


To put it simply, wrap the function in `partial`, then set the arguments afterwards. These must be named arguments - "threshold=0.5" will work, but "0.5" will throw a Python exception because it doesn't know which argument this value applies to.
