### PR TITLE
Add orm classes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from dotenv import load_dotenv
 load_dotenv()
 
-from flask import Flask, render_template, request, flash, make_response, g,  redirect, url_for, send_file, jsonify, send_from_directory
+from flask import render_template, request, flash, make_response, g,  redirect, url_for, send_file, jsonify, send_from_directory
 from flask_bootstrap import Bootstrap
 from functools import wraps
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,15 @@
+import os
+
+class Config:
+    SQLALCHEMY_TRACK_MODIFICATIONS = True
+class DevelopmentConfig(Config):
+    DEVELOPMENT = True
+    DEBUG = True
+    SQLALCHEMY_DATABASE_URI = os.getenv("DEVELOPMENT_DATABASE_URL")
+class ProductionConfig(Config):
+    DEBUG = False
+    SQLALCHEMY_DATABASE_URI = os.getenv("PRODUCTION_DATABASE_URL")
+config = {
+    "development": DevelopmentConfig,
+    "production": ProductionConfig
+}

--- a/init_app.py
+++ b/init_app.py
@@ -1,0 +1,26 @@
+import os
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_cors import CORS
+# from flask_migrate import Migrate
+
+from config import config
+
+APP_SECRET_KEY = os.getenv('APP_SECRET_KEY', '')
+
+db = SQLAlchemy()
+# migrate = Migrate()
+
+def init_app(config_mode):
+    app = Flask(__name__)
+    CORS(app, resources={r"/*": {"origins": "*"}})
+    app.secret_key = APP_SECRET_KEY  # Set a secret key for security purposes
+    app.config.from_object(config["development"])
+    app.config['SESSION_COOKIE_SECURE'] = True
+    app.config['SESSION_COOKIE_HTTPONLY'] = True
+    app.config['REMEMBER_COOKIE_SECURE'] = True
+
+    db.init_app(app)
+    # migrate.init_app(app, db)
+
+    return app

--- a/init_app.py
+++ b/init_app.py
@@ -1,5 +1,6 @@
 import os
-from flask import Flask
+import sqlite3
+from flask import Flask, g
 from flask_sqlalchemy import SQLAlchemy
 from flask_cors import CORS
 # from flask_migrate import Migrate
@@ -7,6 +8,7 @@ from flask_cors import CORS
 from config import config
 
 APP_SECRET_KEY = os.getenv('APP_SECRET_KEY', '')
+SQLLITE_DB_PATH = os.getenv('SQLLITE_DB_PATH', '')
 
 db = SQLAlchemy()
 # migrate = Migrate()
@@ -19,8 +21,15 @@ def init_app(config_mode):
     app.config['SESSION_COOKIE_SECURE'] = True
     app.config['SESSION_COOKIE_HTTPONLY'] = True
     app.config['REMEMBER_COOKIE_SECURE'] = True
-
     db.init_app(app)
     # migrate.init_app(app, db)
 
     return app
+
+def get_db():
+    db = getattr(g, '_database', None)
+    if db is None:
+        db = g._database = sqlite3.connect(SQLLITE_DB_PATH)
+        # This enables column access by name: row['column_name']
+        db.row_factory = sqlite3.Row
+    return db

--- a/models.py
+++ b/models.py
@@ -1,9 +1,11 @@
-from ..app import db
+from init_app import db
 from datetime import datetime
 from flask_login import UserMixin
 from modules.db.utils import get_db
 
 class Query(db.Model):
+    __tablename__ = 'content_queries'
+
     # Auto Generated Fields:
     id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
@@ -18,6 +20,8 @@ class Query(db.Model):
 
 
 class Result(db.Model):
+    __tablename__ = 'content_queries_results'
+
     # Auto Generated Fields:
     id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
@@ -33,6 +37,8 @@ class Result(db.Model):
     cq_id        = db.Column(db.String(100), nullable=True, unique=False)
 
 class SiteIndicator(db.Model):
+    __tablename__ = 'site_fingerprint'
+
     # Auto Generated Fields:
     id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
@@ -44,6 +50,8 @@ class SiteIndicator(db.Model):
     domain        = db.Column(db.String(100), nullable=False, unique=False)
 
 class SiteBase(db.Model):
+    __tablename__ = 'sites_base'
+
     # Auto Generated Fields:
     id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
@@ -54,6 +62,8 @@ class SiteBase(db.Model):
     source       = db.Column(db.String(100), nullable=False, unique=False)
 
 class SiteUser(db.Model):
+    __tablename__ = 'sites_user'
+
     # Auto Generated Fields:
     id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
@@ -64,6 +74,8 @@ class SiteUser(db.Model):
     source       = db.Column(db.String(100), nullable=False, unique=False)
 
 class User(UserMixin):
+    __tablename__ = 'users'
+
     def __init__(self, id, username, password):
         self.id = id
         self.username = username

--- a/models.py
+++ b/models.py
@@ -1,13 +1,14 @@
-from init_app import db
 from datetime import datetime
 from flask_login import UserMixin
-from modules.db.utils import get_db
+
+from init_app import get_db, db
+
 
 class Query(db.Model):
     __tablename__ = 'content_queries'
 
     # Auto Generated Fields:
-    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    id           = db.Column(db.Integer, primary_key=True,  autoincrement=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
     updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
 
@@ -23,7 +24,7 @@ class Result(db.Model):
     __tablename__ = 'content_queries_results'
 
     # Auto Generated Fields:
-    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    id           = db.Column(db.Integer, primary_key=True, autoincrement=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
     updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
 
@@ -40,7 +41,7 @@ class SiteIndicator(db.Model):
     __tablename__ = 'site_fingerprint'
 
     # Auto Generated Fields:
-    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    id           = db.Column(db.Integer, primary_key=True, autoincrement=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
     updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
 
@@ -53,7 +54,7 @@ class SiteBase(db.Model):
     __tablename__ = 'sites_base'
 
     # Auto Generated Fields:
-    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    id           = db.Column(db.Integer, primary_key=True, autoincrement=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
     updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
 
@@ -65,7 +66,7 @@ class SiteUser(db.Model):
     __tablename__ = 'sites_user'
 
     # Auto Generated Fields:
-    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    id           = db.Column(db.Integer, primary_key=True, autoincrement=True)
     created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
     updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
 
@@ -80,6 +81,7 @@ class User(UserMixin):
         self.id = id
         self.username = username
         self.password = password
+
 
     @classmethod
     def get(cls, id):

--- a/modules/models.py
+++ b/modules/models.py
@@ -1,0 +1,80 @@
+from ..app import db
+from datetime import datetime
+from flask_login import UserMixin
+from modules.db.utils import get_db
+
+class Query(db.Model):
+    # Auto Generated Fields:
+    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
+    updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
+
+    # Input by Query Fields:
+    title        = db.Column(db.String(100), nullable=False, unique=False)
+    content      = db.Column(db.String(100), nullable=False, unique=False)
+    combine_operator = db.Column(db.String(100), nullable=True, unique=False)
+    language     = db.Column(db.String(100), nullable=True, unique=False)
+    country      = db.Column(db.String(100), nullable=True, unique=False)
+
+
+class Result(db.Model):
+    # Auto Generated Fields:
+    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
+    updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
+
+    # Input by Query Fields:
+    domain       = db.Column(db.String(100), nullable=False, unique=False)
+    occurrences  = db.Column(db.Integer(), nullable=False, unique=False)
+    title        = db.Column(db.String(100), nullable=True, unique=False)
+    link         = db.Column(db.String(100), nullable=True, unique=False)
+    link_occurrences      = db.Column(db.Integer(), nullable=True, unique=False)
+    engines      = db.Column(db.String(100), nullable=True, unique=False)
+    cq_id        = db.Column(db.String(100), nullable=True, unique=False)
+
+class SiteIndicator(db.Model):
+    # Auto Generated Fields:
+    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
+    updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
+
+    # Input by Query Fields:
+    indicator_type        = db.Column(db.String(100), nullable=False, unique=False)
+    indicator_content     = db.Column(db.String(100), nullable=False, unique=False)
+    domain        = db.Column(db.String(100), nullable=False, unique=False)
+
+class SiteBase(db.Model):
+    # Auto Generated Fields:
+    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
+    updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
+
+    # Input by Query Fields:
+    domain       = db.Column(db.String(100), nullable=False, unique=False)
+    source       = db.Column(db.String(100), nullable=False, unique=False)
+
+class SiteUser(db.Model):
+    # Auto Generated Fields:
+    id           = db.Column(db.String(50), primary_key=True, nullable=False, unique=True)
+    created      = db.Column(db.DateTime(timezone=True), default=datetime.now)
+    updated      = db.Column(db.DateTime(timezone=True), default=datetime.now, onupdate=datetime.now)
+
+    # Input by Query Fields:
+    domain       = db.Column(db.String(100), nullable=False, unique=False)
+    source       = db.Column(db.String(100), nullable=False, unique=False)
+
+class User(UserMixin):
+    def __init__(self, id, username, password):
+        self.id = id
+        self.username = username
+        self.password = password
+
+    @classmethod
+    def get(cls, id):
+        db = get_db()
+        cursor = db.cursor()
+        cursor.execute("SELECT * FROM users WHERE id = ?", (id,))
+        user = cursor.fetchone()
+        if user:
+            return cls(id=user[0], username=user[1], password=user[2])
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ python-dotenv==1.0.0
 flask_cors==4.0.0
 lxml==5.1.0
 bleach==6.1.0
-SQLAlchemy==2.0.29
-pyscopg2==2.9.9
+psycopg2-binary==2.9.9
+Flask-SQLAlchemy==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ python-dotenv==1.0.0
 flask_cors==4.0.0
 lxml==5.1.0
 bleach==6.1.0
+SQLAlchemy==2.0.29
+pyscopg2==2.9.9


### PR DESCRIPTION
Adds ORM classes! Also separates out our config so we can swap in development vs. prod environment databases.

Tested:
- [x] app starts successfully
- [x] basic indicator search works
- [x] matching works 



We use different schemas at the moment for the user class vs the others. I'd like to update the User class to match this one if that's cool.

Current environment variables:
```
DEVELOPMENT_DATABASE_URL = "sqlite:///database.db"
PRODUCTION_DATABASE_URL  = "sqlite:///database.db"
SQLLITE_DB_PATH = './database.db'
```